### PR TITLE
Fix: Suppress ioredis ECONNREFUSED errors

### DIFF
--- a/node_app/app.js
+++ b/node_app/app.js
@@ -11,6 +11,17 @@ const redisClient = new Redis({
     db: parseInt(process.env.REDIS_DB) || 0
 });
 
+redisClient.on('error', (err) => {
+    if (err.code === 'ECONNREFUSED') {
+        console.log('Redis connection refused. Check if Redis is running or accessible.');
+        // Optionally, you might want to use the logger for this, but a simple console.log is fine for suppression.
+        // logger.warn('Redis connection refused. Check if Redis is running or accessible.');
+    } else {
+        // For other errors, log them as before or re-throw if appropriate for your error handling strategy
+        logger.error('Redis client error:', err);
+    }
+});
+
 // Initialize prom-client
 const register = promClient.register;
 promClient.collectDefaultMetrics(); // Collects default Node.js metrics


### PR DESCRIPTION
Adds an error event handler to the ioredis client to specifically catch 'ECONNREFUSED' errors that occur when the Redis instance is not accessible.

Instead of allowing ioredis to output unhandled error events to stderr, this handler logs a more user-friendly message to the console: 'Redis connection refused. Check if Redis is running or accessible.'

This prevents spamming the logs with verbose error messages when Redis is intentionally or unintentionally unavailable, especially during local Dockerized development. Other Redis client errors will still be logged via the existing Winston logger.