### PR TITLE
Fix: Silence ioredis ECONNREFUSED errors in console

### DIFF
--- a/node_app/app.js
+++ b/node_app/app.js
@@ -13,12 +13,9 @@ const redisClient = new Redis({
 
 redisClient.on('error', (err) => {
     if (err.code === 'ECONNREFUSED') {
-        console.log('Redis connection refused. Check if Redis is running or accessible.');
-        // Optionally, you might want to use the logger for this, but a simple console.log is fine for suppression.
-        // logger.warn('Redis connection refused. Check if Redis is running or accessible.');
+        // No console output for ECONNREFUSED from this handler
     } else {
-        // For other errors, log them as before or re-throw if appropriate for your error handling strategy
-        logger.error('Redis client error:', err);
+        logger.error('Redis client error:', err); // Other errors are still logged
     }
 });
 


### PR DESCRIPTION
Updates the error event handler for the ioredis client to completely silence 'ECONNREFUSED' errors in the console. This addresses your feedback that previous logging to the console was still too verbose due to frequent reconnection attempts.

When a Redis connection is refused, the handler for the 'error' event on the ioredis client will now do nothing for errors with the code 'ECONNREFUSED'. This effectively removes these specific error messages from the foreground logs.

Other types of Redis client errors will continue to be logged to both console and file via the existing Winston logger, ensuring that other potential issues remain visible.