### PR TITLE
fix: Adjust asset paths in Swagger UI HTML

### DIFF
--- a/node_app/api/index.html
+++ b/node_app/api/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link rel="stylesheet" type="text/css" href="./swagger-assets/swagger-ui.css">
+  <link rel="stylesheet" type="text/css" href="swagger-assets/swagger-ui.css">
   <style>
     html {
       box-sizing: border-box;
@@ -23,8 +23,8 @@
 </head>
 <body>
   <div id="swagger-ui"></div>
-  <script src="./swagger-assets/swagger-ui-bundle.js"></script>
-  <script src="./swagger-assets/swagger-ui-standalone-preset.js"></script>
+  <script src="swagger-assets/swagger-ui-bundle.js"></script>
+  <script src="swagger-assets/swagger-ui-standalone-preset.js"></script>
   <script>
     window.onload = function() {
       // Begin Swagger UI call region


### PR DESCRIPTION
I modified `node_app/api/index.html` to change how Swagger UI assets (CSS and JS files) are referenced. The leading `./` was removed from paths like `./swagger-assets/swagger-ui.css`.

Paths are now like `swagger-assets/swagger-ui.css`. When `index.html` is served from `/api/` (or `/api/index.html`), these relative paths should resolve to `/api/swagger-assets/filename` in your browser.

This change is intended to fix an issue where these assets were not being loaded correctly (returning HTML instead of JS/CSS), leading to a blank Swagger UI page, as indicated by "Unexpected token '<'" errors in your browser console for the .js files.